### PR TITLE
find and prefer local desktop entries over system-wide desktop entries

### DIFF
--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -18,7 +18,7 @@ HIST_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/${0##*/}-history.txt"
 
 # Get locations of desktop application folders according to spec
 # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-IFS=':' read -ra DIRS <<< "${XDG_CONFIG_HOME-${HOME}/.config}:${XDG_DATA_DIRS-/usr/local/share:/usr/share}"
+IFS=':' read -ra DIRS <<< "${XDG_CONFIG_HOME-${HOME}/.config}:${XDG_DATA_HOME-${HOME}/.local/share}:${XDG_DATA_DIRS-/usr/local/share:/usr/share}"
 
 function describe() {
   if [[ $2 == 'command' ]]; then

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -18,7 +18,7 @@ HIST_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/${0##*/}-history.txt"
 
 # Get locations of desktop application folders according to spec
 # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-IFS=':' read -ra DIRS <<< "${XDG_CONFIG_HOME-${HOME}/.config}:${XDG_DATA_HOME-${HOME}/.local/share}:${XDG_DATA_DIRS-/usr/local/share:/usr/share}"
+IFS=':' read -ra DIRS <<< "${XDG_DATA_HOME-${HOME}/.local/share}:${XDG_DATA_DIRS-/usr/local/share:/usr/share}"
 
 function describe() {
   if [[ $2 == 'command' ]]; then


### PR DESCRIPTION
Currently, local destop entries are ignored. This pull request adds `$XDG_DATA_HOME` to the destop entry search paths before `$XDG_DATA_DIRS` so that local destop entries are preferred over system-wide desktop entries. This is necessary for being able to override system-wide desktop entries for specific users (such as adding command line arguments or environment variables). 