### PR TITLE
Introduce list item providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ The structure looks like this:
 
 ```
 [my-provider]
-list_cmd=echo 'my-custom-entry\034 \034My custom provider'
+list_cmd=echo 'my-custom-entry\034my-provider\034 \034My custom provider'
 preview_cmd=echo 'This is the preview of {1}'
 launch_cmd=notify-send 'I am now launching {1}'
 ```
 
 The `list_cmd` generated the list of entries. For each entry, it has to print the following columns, separated by the `\034` field separator character:
 1. The item to launch. This will get passed to `preview_cmd` and `launch_cmd` as `{1}`
-2. A glyph or any kind of prefix to differentiate your provider from others. Feel free to use ANSI escape codes for coloring it
-3. The text that appears in the `fzf` window
+2. The name of your provider (the same as what what you put inside the brackets, so `my-provider` in this example)
+3. The text that appears in the `fzf` window. You might want to prepend it with a glyph and add some color via ANSI escape codes
 4. (optional) Metadata that you can pass to `preview_cmd` and `launch_cmd` as `{2}`. For example, this is used to specify a specific Desktop Action inside a .desktop file

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Some of your desktop entries will probably be TUI programs that expect to be lau
 ## Extending the launcher
 
 In addition to desktop application entries and binaries, you can extend `sway-launcher-desktop` with custom item providers.
-If will read the configuration of custom item providers from `$HOME/.config/sway-launcher-desktop/providers.conf`
+If will read the configuration of custom item providers from `$HOME/.config/sway-launcher-desktop/providers.conf`.
 The structure looks like this:
 
 ```
@@ -51,3 +51,7 @@ The `list_cmd` generated the list of entries. For each entry, it has to print th
 2. The name of your provider (the same as what what you put inside the brackets, so `my-provider` in this example)
 3. The text that appears in the `fzf` window. You might want to prepend it with a glyph and add some color via ANSI escape codes
 4. (optional) Metadata that you can pass to `preview_cmd` and `launch_cmd` as `{2}`. For example, this is used to specify a specific Desktop Action inside a .desktop file
+
+The `preview_cmd` renders the contents of the `fzf` preview panel. You can use the template variable `{1}` in your command, which will be substituted with the value of the selected item.
+
+The `launch_cmd` is fired when the user has selected one of the provider's entries.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The structure looks like this:
 [my-provider]
 list_cmd=echo 'my-custom-entry\034 \034My custom provider'
 preview_cmd=echo 'This is the preview of {1}'
-launch_cmd=notify-send 'I am not launching {1}'
+launch_cmd=notify-send 'I am now launching {1}'
 ```
 
 The `list_cmd` generated the list of entries. For each entry, it has to print the following columns, separated by the `\034` field separator character:

--- a/README.md
+++ b/README.md
@@ -32,3 +32,22 @@ bindsym $mod+d exec $menu
 
 ### Setup a Terminal command
 Some of your desktop entries will probably be TUI programs that expect to be launched in a new terminal window. Those entries have the `Terminal=true` flag set and you need to tell the launcher which terminal emulator to use. Pass the `TERMINAL_COMMAND` environment variable with your terminal startup command to the script to use your preferred terminal emulator. The script will default to `urxvt -e`
+
+## Extending the launcher
+
+In addition to desktop application entries and binaries, you can extend `sway-launcher-desktop` with custom item providers.
+If will read the configuration of custom item providers from `$HOME/.config/sway-launcher-desktop/providers.conf`
+The structure looks like this:
+
+```
+[my-provider]
+list_cmd=echo 'my-custom-entry\034 \034My custom provider'
+preview_cmd=echo 'This is the preview of {1}'
+launch_cmd=notify-send 'I am not launching {1}'
+```
+
+The `list_cmd` generated the list of entries. For each entry, it has to print the following columns, separated by the `\034` field separator character:
+1. The item to launch. This will get passed to `preview_cmd` and `launch_cmd` as `{1}`
+2. A glyph or any kind of prefix to differentiate your provider from others. Feel free to use ANSI escape codes for coloring it
+3. The text that appears in the `fzf` window
+4. (optional) Metadata that you can pass to `preview_cmd` and `launch_cmd` as `{2}`. For example, this is used to specify a specific Desktop Action inside a .desktop file

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The structure looks like this:
 
 ```
 [my-provider]
-list_cmd=echo 'my-custom-entry\034my-provider\034 \034My custom provider'
-preview_cmd=echo 'This is the preview of {1}'
+list_cmd=echo -e 'my-custom-entry\034my-provider\034  My custom provider'
+preview_cmd=echo -e 'This is the preview of {1}'
 launch_cmd=notify-send 'I am now launching {1}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Some of your desktop entries will probably be TUI programs that expect to be lau
 ## Extending the launcher
 
 In addition to desktop application entries and binaries, you can extend `sway-launcher-desktop` with custom item providers.
-If will read the configuration of custom item providers from `$HOME/.config/sway-launcher-desktop/providers.conf`.
+It will read the configuration of custom item providers from `$HOME/.config/sway-launcher-desktop/providers.conf`.
 The structure looks like this:
 
 ```

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -43,8 +43,6 @@ if [ -f "${CONFIG_DIR}/providers.conf" ]; then
         print "PROVIDERS[\x27" key "\x27]=\x27" providers[key]["list_cmd"] "\034" providers[key]["preview_cmd"] "\034" providers[key]["launch_cmd"] "\x27\n"
     }
   }' "${CONFIG_DIR}/providers.conf")
-  echo "$PARSED"
-
   eval "$PARSED"
 else
   PROVIDERS['desktop']="${0} list-entries${DEL}${0} describe-desktop${DEL}${0} generate-command"

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -46,9 +46,6 @@ fi
 touch "$HIST_FILE"
 readarray HIST_LINES <"$HIST_FILE"
 
-function command-line() {
-  echo "${TERMINAL_COMMAND} ${1}"
-}
 function describe() {
   # shellcheck disable=SC2086
   readarray -d ${DEL} -t PROVIDER_ARGS <<<${PROVIDERS[${1}]}
@@ -198,7 +195,7 @@ function generate-command() {
 }
 
 case "$1" in
-describe | describe-desktop | describe-command | entries | list-entries | list-commands | command-line | generate-command | run-desktop | provide)
+describe | describe-desktop | describe-command | entries | list-entries | list-commands | generate-command | run-desktop | provide)
   "$@"
   exit
   ;;

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -28,19 +28,13 @@ if [ -f "${CONFIG_DIR}/providers.conf" ]; then
   /^(launch|list|preview)_cmd/{st = index($0,"=");providers[provider][$1] = substr($0,st+1)}
   ENDFILE{
     for (key in providers){
-        if(!("list_cmd" in providers[key])){continue;}
-        if(!("launch_cmd" in providers[key])){continue;}
-        if(!("preview_cmd" in providers[key])){continue;}
-        for (entry in providers[key]){
-        #  gsub(/\$/,"\\$", providers[key][entry])
-        #  gsub(/"/,"\\\"", providers[key][entry])
-        #  gsub("\047",sq, providers[key][entry])
-      #    gsub("\x27",sq, providers[key][entry])
-     #     gsub(/\047/,sq, providers[key][entry])
-         gsub(/[\x27,\047]/,"\x27\"\x27\"\x27", providers[key][entry])
-        #  gsub(/\047/,"DURR", providers[key][entry])
-        }
-        print "PROVIDERS[\x27" key "\x27]=\x27" providers[key]["list_cmd"] "\034" providers[key]["preview_cmd"] "\034" providers[key]["launch_cmd"] "\x27\n"
+      if(!("list_cmd" in providers[key])){continue;}
+      if(!("launch_cmd" in providers[key])){continue;}
+      if(!("preview_cmd" in providers[key])){continue;}
+      for (entry in providers[key]){
+       gsub(/[\x27,\047]/,"\x27\"\x27\"\x27", providers[key][entry])
+      }
+      print "PROVIDERS[\x27" key "\x27]=\x27" providers[key]["list_cmd"] "\034" providers[key]["preview_cmd"] "\034" providers[key]["launch_cmd"] "\x27\n"
     }
   }' "${CONFIG_DIR}/providers.conf")
   eval "$PARSED"

--- a/tests/data/config/0/sway-launcher-desktop/providers.conf
+++ b/tests/data/config/0/sway-launcher-desktop/providers.conf
@@ -1,0 +1,7 @@
+[foo]
+list_cmd=printf "foo\034foo"
+launch_cmd=printf 'printf "{1}"'
+preview_cmd=printf 'printf "{1}"'
+
+[incomplete]
+list_cmd=echo 'nope'

--- a/tests/describe.bats
+++ b/tests/describe.bats
@@ -1,12 +1,12 @@
 @test "Name and description of firefox desktop file are properly extracted" {
-  run ../sway-launcher-desktop.sh describe data/desktop-files/0/applications/firefox.desktop desktop
+  run env XDG_CONFIG_HOME=./data/config ../sway-launcher-desktop.sh describe desktop ./data/desktop-files/0/applications/firefox.desktop
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ "Firefox" ]]
   [[ ${lines[1]} =~ "Browse the World Wide Web" ]]
 }
 
 @test "Name and description of ls command should be given" {
-  run ../sway-launcher-desktop.sh describe ls command
+  run env XDG_CONFIG_HOME=./data/config ../sway-launcher-desktop.sh describe command ls
   [ "$status" -eq 0 ]
   [[ ${lines[0]} =~ "ls" ]]
   [[ ${lines[1]} =~ "list directory contents" ]]

--- a/tests/providers.bats
+++ b/tests/providers.bats
@@ -1,0 +1,36 @@
+@test "Builtin desktop provider works" {
+  run  env XDG_CONFIG_HOME=./data/config XDG_DATA_HOME=./data/desktop-files/1 XDG_DATA_DIRS=./data/desktop-files/0 ../sway-launcher-desktop.sh provide desktop
+  echo  "OUTPUT:$output"
+  echo  "LINES:${#lines[@]}"
+  [ "$status" -eq 0 ]
+  [[ ${#lines[@]} -gt 2 ]]
+}
+
+@test "Builtin command provider works" {
+  run  env XDG_CONFIG_HOME=./data/config XDG_DATA_HOME=./data/desktop-files/1 XDG_DATA_DIRS=./data/desktop-files/0 ../sway-launcher-desktop.sh provide command
+  echo  "OUTPUT:$output"
+  echo  "LINES:${#lines[@]}"
+  [ "$status" -eq 0 ]
+  [[ ${#lines[@]} -gt 2 ]]
+}
+
+@test "Reads custom provider from providers.conf" {
+  run  printf %q "$(env XDG_CONFIG_HOME=./data/config/0 ../sway-launcher-desktop.sh provide foo)"
+  echo  "OUTPUT:$output"
+  [ "$status" -eq 0 ]
+  [[ ${output} ==  "$'foo\034foo'" ]]
+}
+
+@test "Skips incomplete custom provider from providers.conf" {
+  run  printf %q "$(env XDG_CONFIG_HOME=./data/config/0 ../sway-launcher-desktop.sh provide incomplete)"
+  echo  "OUTPUT:$output"
+  [ "$status" -eq 0 ]
+  [[ ${output} ==  "''" ]]
+}
+
+@test "Does not use builtin providers when reading from providers.conf" {
+  run  printf %q "$(env XDG_CONFIG_HOME=./data/config/0 ../sway-launcher-desktop.sh provide desktop)"
+  echo  "OUTPUT:$output"
+  [ "$status" -eq 0 ]
+  [[ ${output} ==  "''" ]]
+}


### PR DESCRIPTION
This PR extends the launcher script with the following:
- Existing list items are refactored into 2 separate "providers": `command` and `desktop`
- Instead of hardcoding how the list of items is generated, the script now iterates over the array of providers
- A configuration file is read, allowing users to defined their own providers
- Basic documentation is added to the README

I hope people will find this useful