### PR TITLE
Remove man-page reference from command description

### DIFF
--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -59,7 +59,7 @@ function describe-desktop() {
 function describe-command() {
   readarray arr < <(whatis -l "$1" 2>/dev/null)
   description="${arr[0]}"
-  description="${description%*-}"
+  description="${description#* - }"
   echo -e "\033[33m${1}\033[0m"
   echo "${description:-No description}"
 }


### PR DESCRIPTION
Currently, the full output of `whatis` is shown as the description of a command. This includes a reference to the command's man-page and a lot of whitespace before the actual description.
This PR removes this arguably superfluous information, displaying only the short description for more consistency with desktop entries.
I believe the code already intends this, but uses the wrong obscure bash parameter expansion character.