### PR TITLE
Support switching between different provider configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,6 @@ The `list_cmd` generated the list of entries. For each entry, it has to print th
 The `preview_cmd` renders the contents of the `fzf` preview panel. You can use the template variable `{1}` in your command, which will be substituted with the value of the selected item.
 
 The `launch_cmd` is fired when the user has selected one of the provider's entries.
+
+Note: Pass the environment variable `PROVIDERS_FILE` to read custom providers from another file than the default `providers.conf`.
+The path in `PROVIDERS_FILE` can either be absolute or relative to `${HOME}/.config/sway-launcher-desktop/`.


### PR DESCRIPTION
This PR adds support for switching between multiple provider configurations. The environment variable `PROVIDERS_FILE` can be used to select which file `sway-launcher-desktop` uses. If not set, the currently hardcoded `providers.conf` is used.

Being able to select from different sets of providers enables setting up several launchers for different purposes (e.g. to run applications, open bookmarks, copy passwords or OTP tokens, ...).

I changed the history file name to include the name of the provider config file. This is a slight incompatibility with current `master`. However, mixing histories between providers that supply different commands does not make much sense in general, so this seems necessary.