### PR TITLE
Support desktop files and commands containing single quotes

### DIFF
--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -44,8 +44,8 @@ if [ -f "${PROVIDERS_FILE}" ]; then
   }' "${PROVIDERS_FILE}")"
   HIST_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/${0##*/}-${PROVIDERS_FILE##*/}-history.txt"
 else
-  PROVIDERS['desktop']="${0} list-entries${DEL}${0} describe-desktop '{1}'${DEL}${0} run-desktop '{1}' {2}"
-  PROVIDERS['command']="${0} list-commands${DEL}${0} describe-command {1}${DEL}${TERMINAL_COMMAND} {1}"
+  PROVIDERS['desktop']="${0} list-entries${DEL}${0} describe-desktop \"{1}\"${DEL}${0} run-desktop '{1}' {2}"
+  PROVIDERS['command']="${0} list-commands${DEL}${0} describe-command \"{1}\"${DEL}${TERMINAL_COMMAND} {1}"
   HIST_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/${0##*/}-history.txt"
 fi
 


### PR DESCRIPTION
This PR fixes an issue caused by filenames containing  `'` characters.
For example, a file named `Sid Meier's Civilization IV.desktop` yields the following description:
```
╭────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ /usr/bin/sway-launcher-desktop: eval: line 59: unexpected EOF while looking for matching `''       │
│ /usr/bin/sway-launcher-desktop: eval: line 60: syntax error: unexpected end of file                │
│ /usr/bin/sway-launcher-desktop: Error on line 234: eval "${PROVIDER_ARGS[1]//\{1\}/${2}}"          │
╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
This is fixed by wrapping the argument to `describe-desktop` in double quotes.
This also applies to the 'command' provider and `describe-command`.