### PR TITLE
Make TERMINAL_COMMAND use $TERM instead of urxvt

### DIFF
--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -12,10 +12,7 @@ trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 IFS=$'\n\t'
 DEL=$'\34'
 
-# Defaulting terminal to urxvt, but feel free to either change
-# this or override with an environment variable in your sway config
-# It would be good to move this to a config file eventually
-TERMINAL_COMMAND="${TERMINAL_COMMAND:="urxvt -e"}"
+TERMINAL_COMMAND="${TERMINAL_COMMAND:="$TERM -e"}"
 GLYPH_COMMAND="  "
 GLYPH_DESKTOP="  "
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/sway-launcher-desktop"


### PR DESCRIPTION
`urxvt` doesn't make sense as a default, as $TERM is standard:
https://linux.die.net/man/7/term.