### PR TITLE
Allow arbitrary Command input

### DIFF
--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -257,12 +257,21 @@ done
 
 COMMAND_STR=$(
   fzf +s -x -d '\034' --nth ..3 --with-nth 3 \
+    --print-query \
     --preview "$0 describe {2} {1}" \
     --preview-window=up:3:wrap --ansi \
-    <"$FZFPIPE"
-) || exit 1
+    <"$FZFPIPE" 
+) || true
 
-[ -z "$COMMAND_STR" ] && exit 1
+LINE_COUNT=$(echo "$COMMAND_STR" | wc -l)
+if [ $LINE_COUNT = 2 ]; then
+    QUERY_STR=$(echo "$COMMAND_STR" | head -1 )
+    COMMAND_STR=$(echo "$COMMAND_STR" | tail -n +2 | xargs)
+fi
+if [ $LINE_COUNT = 1 ]; then
+    [ -z "$COMMAND_STR" ] && exit 1
+    COMMAND_STR="$COMMAND_STR"$'\034command\034'"$COMMAND_STR"$'\034'
+fi
 
 if [[ -n "${HIST_FILE}" ]]; then
   # update history


### PR DESCRIPTION
Regarding #27, I implemented this first (dirty, see code) version of executing arbitrary commands. It works by parsing the output of fzf with --print-query enabled. If there is only one line (the query), it constructs a synthetic command-entry and launches that.

Please critique this code heavily as I am not a regular shell programmer.