### PR TITLE
Allow overriding default glyphs, "cleaner" UI, make configuration not URxvt-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ Arch Linux users can also grab it from the AUR (thanks @turtlewit)
 
 Configure it in Sway like this:
 ```
-for_window [class="URxvt" instance="launcher"] floating enable, border pixel 10, sticky enable
-set $menu exec urxvt -geometry 55x18 -name launcher -e env TERMINAL_COMMAND="urxvt -e" /path/to/repo/sway-launcher-desktop.sh
+for_window [app_id="^launcher$"] floating enable, sticky enable, resize set 30 ppt 60 ppt, border pixel 10
+set $menu exec $term --class=launcher -e /path/to/repo/sway-launcher-desktop.sh
 bindsym $mod+d exec $menu
 ```
 
-
+You can override the default icons/glyphs by setting the appropriate GLYPH_ variable in your $menu command, e.g.:
+```
+set $menu exec $term --class=launcher -e env GLYPH_COMMAND="" GLYPH_DESKTOP="" GLYPH_PROMPT="? " sway-launcher
+```
 
 ### Setup a Terminal command
 Some of your desktop entries will probably be TUI programs that expect to be launched in a new terminal window. Those entries have the `Terminal=true` flag set and you need to tell the launcher which terminal emulator to use. Pass the `TERMINAL_COMMAND` environment variable with your terminal startup command to the script to use your preferred terminal emulator. The script will default to `$TERM -e`

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -13,12 +13,8 @@ IFS=$'\n\t'
 DEL=$'\34'
 
 TERMINAL_COMMAND="${TERMINAL_COMMAND:="$TERM -e"}"
-if [[ -n $GLYPH_COMMAND ]]; then
-  GLYPH_COMMAND="  "
-fi
-if [[ -n $GLYPH_DESKTOP ]]; then
-  GLYPH_DESKTOP="  "
-fi
+GLYPH_COMMAND="${GLYPH_COMMAND-  }"
+GLYPH_DESKTOP="${GLYPH_DESKTOP-  }"
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/sway-launcher-desktop"
 PROVIDERS_FILE="${PROVIDERS_FILE:=providers.conf}"
 if [[ "${PROVIDERS_FILE#/}" == "${PROVIDERS_FILE}" ]]; then

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -256,10 +256,13 @@ for PROVIDER_NAME in "${!PROVIDERS[@]}"; do
 done
 
 COMMAND_STR=$(
-  fzf +s -x -d '\034' --nth ..3 --with-nth 3 \
+  fzf --ansi +s -x -d '\034' --nth ..3 --with-nth 3 \
     --preview "$0 describe {2} {1}" \
-    --preview-window=up:3:wrap --ansi \
-    --no-info --margin="3%" --cycle \
+    --preview-window=up:2:noborder \
+    --no-mouse --no-multi --cycle \
+    --prompt="${GLYPH_PROMPT-# }" \
+    --header='' --no-info --margin='1,2' \
+    --color='16,gutter:-1' \
     <"$FZFPIPE"
 ) || exit 1
 

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -259,7 +259,7 @@ COMMAND_STR=$(
   fzf --ansi +s -x -d '\034' --nth ..3 --with-nth 3 \
     --preview "$0 describe {2} {1}" \
     --preview-window=up:2:noborder \
-    --no-mouse --no-multi --cycle \
+    --no-multi --cycle \
     --prompt="${GLYPH_PROMPT-# }" \
     --header='' --no-info --margin='1,2' \
     --color='16,gutter:-1' \

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -13,8 +13,12 @@ IFS=$'\n\t'
 DEL=$'\34'
 
 TERMINAL_COMMAND="${TERMINAL_COMMAND:="$TERM -e"}"
-GLYPH_COMMAND="  "
-GLYPH_DESKTOP="  "
+if [[ -n $GLYPH_COMMAND ]]; then
+  GLYPH_COMMAND="  "
+fi
+if [[ -n $GLYPH_DESKTOP ]]; then
+  GLYPH_DESKTOP="  "
+fi
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/sway-launcher-desktop"
 PROVIDERS_FILE="${PROVIDERS_FILE:=providers.conf}"
 if [[ "${PROVIDERS_FILE#/}" == "${PROVIDERS_FILE}" ]]; then
@@ -259,6 +263,7 @@ COMMAND_STR=$(
   fzf +s -x -d '\034' --nth ..3 --with-nth 3 \
     --preview "$0 describe {2} {1}" \
     --preview-window=up:3:wrap --ansi \
+    --no-info --margin="3%" --cycle \
     <"$FZFPIPE"
 ) || exit 1
 

--- a/tests/autostart.bats
+++ b/tests/autostart.bats
@@ -1,3 +1,5 @@
+#!/usr/bin/env bats
+
 setup() {
    export TERMINAL_COMMAND='urxvt -e'
    export XDG_CONFIG_HOME=./data/autostart-folders/0

--- a/tests/describe.bats
+++ b/tests/describe.bats
@@ -1,3 +1,5 @@
+#!/usr/bin/env bats
+
 @test "Name and description of firefox desktop file are properly extracted" {
   run env XDG_CONFIG_HOME=./data/config ../sway-launcher-desktop.sh describe desktop ./data/desktop-files/0/applications/firefox.desktop
   [ "$status" -eq 0 ]

--- a/tests/entries.bats
+++ b/tests/entries.bats
@@ -1,3 +1,5 @@
+#!/usr/bin/env bats
+
 @test "Firefox desktop entry and all its actions are extracted" {
   run ../sway-launcher-desktop.sh entries data/desktop-files/0/applications/firefox.desktop
   echo -e "OUTPUT:\n$output"

--- a/tests/generate-command.bats
+++ b/tests/generate-command.bats
@@ -1,3 +1,5 @@
+#!/usr/bin/env bats
+
 setup() {
    export TERMINAL_COMMAND='urxvt -e'
 }

--- a/tests/providers.bats
+++ b/tests/providers.bats
@@ -1,3 +1,5 @@
+#!/usr/bin/env bats
+
 @test "Builtin desktop provider works" {
   run  env XDG_CONFIG_HOME=./data/config XDG_DATA_HOME=./data/desktop-files/1 XDG_DATA_DIRS=./data/desktop-files/0 ../sway-launcher-desktop.sh provide desktop
   echo  "OUTPUT:$output"


### PR DESCRIPTION
Hi! I made a few changes to this. If you'd rather have them as individual PRs/Patches I'll sit down and do that. Also, if any of the UI changes are too opinionated for you, I'm sure we can figure something out. Summary:

### Overridable Glyphs:

As cute as the rockets are, I prefer not having them - and others perhaps, too. They can be overridden by passing `GLYPH_` variables to the `$menu` invocation from sway config, as described in the readme. The default retains the rockets.

### "Cleaner" UI:

I sat down and read through `man fzf`, as the launcher seems somewhat cluttered. I suppose we can agree that the line with the number of matching and total items, as well as the "gutter" on the side provide no benefit to the launcher. I also played around with margins, spacing, and added `--no-mouse`, `--no-multi` and `--cycle` to the `fzf` arguments. As said, if any of these are too opinionated, let me know. Here's a snapshot of what the default config looks like on my machine (there's no hardcoded colors, it's my default terminal theme).

![image](https://user-images.githubusercontent.com/34752364/102891299-3dd64800-445e-11eb-862e-30e752eb8c57.png)

It could probably be tweaked a little further, such as giving the preview and input boxes a different background color, but I'm not sure if that's desired.

### Non-URvxt-specific configuration

The setup instructions in the readme seem to only consider URvxt. I for one use Alacritty, and it works just fine by using pure sway configuration rather than passing flags around inside the `$menu` cmdline.

Let me know if this flies with you or if there's anything you'd like to see changed. Loving this script, it's a lot more hackable than the next best thing I could find (`wofi` :P) that kinda sorta did what I wanted.