### PR TITLE
Hide applications with NoDisplay=true

### DIFF
--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -113,6 +113,7 @@ function entries() {
     }
     BEGINFILE{
       application=0;
+      hidden=0;
       block="";
       a=0
 
@@ -140,12 +141,15 @@ function entries() {
       actions[a,"key"]=$0
     }
     /^Name=/{ (block=="action")? actions[a,"name"]=$2 : name=$2 }
+    /^NoDisplay=true/{ (block=="action")? actions[a,"hidden"]=1 : hidden=1 }
     ENDFILE{
       if (application){
-          print FILENAME "\034desktop\034\033[33m" pre name "\033[0m";
+          if (!hidden)
+              print FILENAME "\034desktop\034\033[33m" pre name "\033[0m";
           if (a>0)
               for (i=1; i<=a; i++)
-                  print FILENAME "\034desktop\034\033[33m" pre name "\033[0m (" actions[i, "name"] ")\034" actions[i, "key"]
+                  if (!actions[i, "hidden"])
+                      print FILENAME "\034desktop\034\033[33m" pre name "\033[0m (" actions[i, "name"] ")\034" actions[i, "key"]
       }
     }' \
     $@ </dev/null

--- a/tests/data/desktop-files/0/applications/nvim.desktop
+++ b/tests/data/desktop-files/0/applications/nvim.desktop
@@ -1,0 +1,19 @@
+[Desktop Entry]
+Version=1.0
+Name=Neovim
+Type=Application
+Terminal=true
+Exec=nvim
+NoDisplay=true
+GenericName=Text Editor
+
+[Desktop Action new-file]
+Name=New File
+Terminal=true
+Exec=nvim
+
+[Desktop Action open-file]
+Name=Open File
+Terminal=true
+NoDisplay=true
+Exec=nvim

--- a/tests/data/desktop-files/0/applications/vim.desktop
+++ b/tests/data/desktop-files/0/applications/vim.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Name=Vim
+Type=Application
+Terminal=true
+Exec=vim
+NoDisplay=true
+GenericName=Text Editor

--- a/tests/entries.bats
+++ b/tests/entries.bats
@@ -22,12 +22,20 @@
 @test "Wildcard expansion works for extraction of desktop files" {
   run ../sway-launcher-desktop.sh entries data/desktop-files/0/applications/*.desktop
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} ==  8 ]]
+  [[ ${#lines[@]} ==  9 ]]
 }
 
 @test "Reoccurring desktop file ids are not parsed twice" {
   run ../sway-launcher-desktop.sh entries data/desktop-files/**/*.desktop
     echo "EXPECTED: foo-bar.desktop ACTUAL: $output"
   [ "$status" -eq 0 ]
-  [[ ${#lines[@]} ==  8 ]]
+  [[ ${#lines[@]} ==  9 ]]
+}
+
+@test "Hidden desktop entries are ignored" {
+  run ../sway-launcher-desktop.sh entries data/desktop-files/0/applications/*vim.desktop
+  [ "$status" -eq 0 ]
+  [[ ${#lines[@]} == 1 ]]
+  [[ ${lines[0]} =~ data/desktop-files/0/applications/nvim.desktop ]]
+  [[ ${lines[0]} =~ ^data/desktop-files/0/applications/nvim.desktop.*Neovim.*(New File).*new-file ]]
 }


### PR DESCRIPTION
Hi,
thanks for creating sway-launcher-desktop! Personally, I have a lot of `.desktop` entries with `NoDisplay=true`, but that options is currently not respected and the entries are being shown in the launcher. So I made this PR to fix it.

I’m not really familiar with how Bats tests work, so I hope I didn’t break them.

Fixes #32.