### PR TITLE
Don’t autostart applications with Hidden=true

### DIFF
--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -227,6 +227,7 @@ function list-autostart() {
     BEGINFILE{
       application=0;
       block="";
+      disabled=0;
       a=0
 
       id=desktopFileID(FILENAME)
@@ -239,8 +240,9 @@ function list-autostart() {
     /^\[Desktop Entry\]/{block="entry"}
     /^Type=Application/{application=1}
     /^Name=/{ iname=$2 }
+    /^Hidden=true/{disabled=1}
     ENDFILE{
-      if (application){
+      if (application && !disabled){
           print FILENAME;
       }
     }' \

--- a/tests/data/autostart-folders/0/autostart/vim.desktop
+++ b/tests/data/autostart-folders/0/autostart/vim.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Name=Vim
+Exec=/sbin/vim
+Terminal=true
+Type=Application
+Hidden=true

--- a/tests/data/autostart-folders/1/autostart/firefox.desktop
+++ b/tests/data/autostart-folders/1/autostart/firefox.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Firefox
+Hidden=true
 GenericName=Web Browser
 GenericName[ar]=متصفح ويب
 GenericName[ast]=Restolador Web

--- a/tests/data/autostart-folders/1/autostart/vim.desktop
+++ b/tests/data/autostart-folders/1/autostart/vim.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Version=1.0
+Name=Vim
+Exec=/sbin/vim
+Terminal=true
+Type=Application


### PR DESCRIPTION
Hi! The [XDG Autostart specification says](https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html#idm45695371813952) that entries with `Hidden=true` should be ignored and not autostarted. However, sway-launcher-desktop does not check for that option and therefore autostarts all entries without the user being able to disable them.

I added a check to `list-autostart` that excludes such entries. Thanks for looking at this.