### PR TITLE
Introduce function to purge invalid entries from history

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For example, if you wish to launch your programs with `swaymsg exec`, you can do
  swaymsg exec "$(./sway-launcher-desktop.sh)"
 ```
 
-### Setup a Terminal command
+### Set up a Terminal command
 Some of your desktop entries will probably be TUI programs that expect to be launched in a new terminal window. Those entries have the `Terminal=true` flag set and you need to tell the launcher which terminal emulator to use. Pass the `TERMINAL_COMMAND` environment variable with your terminal startup command to the script to use your preferred terminal emulator. The script will default to `$TERMINAL -e`
 
 ### Configure application autostart
@@ -100,6 +100,12 @@ By default, `sway-launcher-desktop` stores a history of commands to make frequen
 This history is stored in a file in `~/.cache/` (or `$XDG_CACHE_HOME`, if that environment variable is set).
 You may change the file path and name by setting the environment variable `HIST_FILE` to the desired path.
 Setting the variable to an empty value disables the history feature entirely.
+
+### Housekeeping
+After a while, this history might grow and contain some invalid entries due to removed/renamed programs etc.
+You can use `./sway-launcher-desktop.sh purge` to identify broken entries and remove them.
+Consider adding this command to a cronjob, startup script, or maybe even hook it into your package manager.
+
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The structure looks like this:
 list_cmd=echo -e 'my-custom-entry\034my-provider\034  My custom provider'
 preview_cmd=echo -e 'This is the preview of {1}'
 launch_cmd=notify-send 'I am now launching {1}'
+purge_cmd=command -v '{1}' || exit 43
 ```
 
 The `list_cmd` generated the list of entries. For each entry, it has to print the following columns, separated by the `\034` field separator character:
@@ -73,6 +74,8 @@ The `list_cmd` generated the list of entries. For each entry, it has to print th
 The `preview_cmd` renders the contents of the `fzf` preview panel. You can use the template variable `{1}` in your command, which will be substituted with the value of the selected item.
 
 The `launch_cmd` is fired when the user has selected one of the provider's entries.
+
+The `purge_cmd` is used as part of the `purge` function. It tests any entry of a provider. If the test exits with `43`, then the entry will be removed from the history file
 
 Note: Pass the environment variable `PROVIDERS_FILE` to read custom providers from another file than the default `providers.conf`.
 The path in `PROVIDERS_FILE` can either be absolute or relative to `${HOME}/.config/sway-launcher-desktop/`.
@@ -87,11 +90,13 @@ So you can simply mimick their behaviour by placing this in your config file:
 list_cmd=/path/to/sway-launcher-desktop.sh list-entries
 preview_cmd=/path/to/sway-launcher-desktop.sh describe-desktop "{1}"
 launch_cmd=/path/to/sway-launcher-desktop.sh run-desktop '{1}' {2}
+purge_cmd=test -f '{1}' || exit 43
 
 [command]
 list_cmd=/path/to/sway-launcher-desktop.sh list-commands
 preview_cmd=/path/to/sway-launcher-desktop.sh describe-command "{1}"
 launch_cmd=$TERMINAL_COMMAND {1}
+purge_cmd=command -v '{1}' || exit 43
 ```
 
 ## Launcher history file

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -46,8 +46,8 @@ if [ -f "${PROVIDERS_FILE}" ]; then
     HIST_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/${0##*/}-${PROVIDERS_FILE##*/}-history.txt"
   fi
 else
-  PROVIDERS['desktop']="${0} list-entries${DEL}${0} describe-desktop \"{1}\"${DEL}${0} run-desktop '{1}' {2}${DEL}test -f {1}"
-  PROVIDERS['command']="${0} list-commands${DEL}${0} describe-command \"{1}\"${DEL}${TERMINAL_COMMAND} {1}${DEL}command -v {1}"
+  PROVIDERS['desktop']="${0} list-entries${DEL}${0} describe-desktop \"{1}\"${DEL}${0} run-desktop '{1}' {2}${DEL}test -f '{1}' || exit 43"
+  PROVIDERS['command']="${0} list-commands${DEL}${0} describe-command \"{1}\"${DEL}${TERMINAL_COMMAND} {1}${DEL}command -v '{1}' || exit 43"
   if [[ ! -v HIST_FILE ]]; then
     HIST_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/${0##*/}-history.txt"
   fi
@@ -252,20 +252,21 @@ function list-autostart() {
 }
 
 purge() {
+ # shellcheck disable=SC2188
  > "${HIST_FILE}"
  declare -A PURGE_CMDS
  for PROVIDER_NAME in "${!PROVIDERS[@]}"; do
    readarray -td ${DEL} PROVIDER_ARGS <<<${PROVIDERS[${PROVIDER_NAME}]}
    PURGE_CMD=${PROVIDER_ARGS[3]}
-   [ -z "${PURGE_CMD}" ] && PURGE_CMD='test -f {1}'
+   [ -z "${PURGE_CMD}" ] && PURGE_CMD='test -f "{1}" || exit 43'
    PURGE_CMDS[$PROVIDER_NAME]="${PURGE_CMD%$'\n'}"
   done
   for HIST_LINE in "${HIST_LINES[@]#*' '}"; do
     readarray -td $'\034' HIST_ENTRY <<<${HIST_LINE}
     ENTRY=${HIST_ENTRY[1]}
     readarray -td ' ' FILTER <<<${PURGE_CMDS[$ENTRY]//\{1\}/${HIST_ENTRY[0]}}
-    "${FILTER[@]%$'\n'}" 1>/dev/null # Run filter command discarding output. We only want the exit status
-    if [[ $? -eq 0 ]]; then
+    (eval "${FILTER[@]}" 1>/dev/null) # Run filter command discarding output. We only want the exit status
+    if [[ $? -ne 43 ]]; then
       echo "1 ${HIST_LINE[@]%$'\n'}" >> "${HIST_FILE}"
     fi
   done

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -3,7 +3,7 @@
 # Based on: https://gitlab.com/FlyingWombat/my-scripts/blob/master/sway-launcher
 # https://gist.github.com/Biont/40ef59652acf3673520c7a03c9f22d2a
 shopt -s nullglob globstar
-set -xo pipefail
+set -o pipefail
 if ! { exec 0>&3; } 1>/dev/null 2>&1; then
   exec 3>/dev/null # If file descriptor 3 is unused in parent shell, output to /dev/null
 fi
@@ -251,6 +251,7 @@ function list-autostart() {
 }
 
 purge() {
+ > "${HIST_FILE}"
  declare -A PURGE_CMDS
  for PROVIDER_NAME in "${!PROVIDERS[@]}"; do
    readarray -td ${DEL} PROVIDER_ARGS <<<${PROVIDERS[${PROVIDER_NAME}]}
@@ -258,12 +259,12 @@ purge() {
    [ -z "${PURGE_CMD}" ] && PURGE_CMD='test -f {1}'
    PURGE_CMDS[$PROVIDER_NAME]="${PURGE_CMD%$'\n'}"
   done
-  for HIST_LINE in "${HIST_LINES[@]#* }"; do
+  for HIST_LINE in "${HIST_LINES[@]#*' '}"; do
     readarray -td $'\034' HIST_ENTRY <<<${HIST_LINE}
     ENTRY=${HIST_ENTRY[1]}
     readarray -td ' ' FILTER <<<${PURGE_CMDS[$ENTRY]//\{1\}/${HIST_ENTRY[0]}}
    "${FILTER[@]%$'\n'}" 1>/dev/null # Run filter command discarding output. We only want the exit status
-   [ $? -eq 0 ] && echo "yay"
+   [ $? -eq 0 ] && echo "1 ${HIST_LINE[@]%$'\n'}" >> "${HIST_FILE}"
   done
 }
 

--- a/tests/history-purge.bats
+++ b/tests/history-purge.bats
@@ -14,12 +14,14 @@ setup() {
    echo "1 ${SLD_DESKTOP_ROOT}cjsdalkcnjsaddesktop  I wanna be purged" >> "$SLD_HIST_FILE"
    echo "1 awkcommand  awk" >> "$SLD_HIST_FILE"
    echo "1 xksdkasjkslajdslakcommand  I wanna be purged" >> "$SLD_HIST_FILE"
+   echo "1 xksdkasjkslajdslakcommand  I wanna be purged too" >> "$SLD_HIST_FILE"
 }
 
 @test "Purge command removes invalid entries" {
   run ../sway-launcher-desktop.sh purge
   readarray HIST_LINES <"$SLD_HIST_FILE"
-  cat "$SLD_HIST_FILE"
+#  cat "$SLD_HIST_FILE"
+  echo "$output"
   [ "$status" -eq 0 ]
   [[ ${#HIST_LINES[@]} ==  2 ]]
 }

--- a/tests/history-purge.bats
+++ b/tests/history-purge.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+setup() {
+   export TERMINAL_COMMAND='urxvt -e'
+   export XDG_DATA_HOME=./data/desktop-files/0
+   export SLD_DESKTOP_ROOT="$XDG_DATA_HOME/applications/"
+   export XDG_CACHE_HOME=$BATS_TEST_TMPDIR
+   export XDG_CONFIG_HOME=./data/autostart-folders/0
+   export XDG_CONFIG_DIRS=./data/autostart-folders/1
+   export SLD_HIST_FILE="$BATS_TEST_TMPDIR/sway-launcher-desktop.sh-history.txt"
+   touch "$SLD_HIST_FILE"
+
+   echo "1 ${SLD_DESKTOP_ROOT}firefox.desktopdesktop  Firefox" >> "$SLD_HIST_FILE"
+   echo "1 ${SLD_DESKTOP_ROOT}cjsdalkcnjsaddesktop  I wanna be purged" >> "$SLD_HIST_FILE"
+   echo "1 awkcommand  awk" >> "$SLD_HIST_FILE"
+   echo "1 xksdkasjkslajdslakcommand  I wanna be purged" >> "$SLD_HIST_FILE"
+}
+
+@test "Purge command removes invalid entries" {
+  run ../sway-launcher-desktop.sh purge
+  readarray HIST_LINES <"$SLD_HIST_FILE"
+  cat "$SLD_HIST_FILE"
+  [ "$status" -eq 0 ]
+  [[ ${#HIST_LINES[@]} ==  2 ]]
+}


### PR DESCRIPTION
Fix #50 

Introduces a public function that iterates over the history file and runs each line against a validation callback (referred to as `purge_cmd` when writing custom providers)

If this command ~exits with `0`, the entry is kept in the file~ exits with `43`, the entry is removed from file.