### PR TITLE
Make fzf path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ You can override the default icons/glyphs by setting the appropriate GLYPH_ vari
 set $menu exec $term -e env GLYPH_COMMAND="" GLYPH_DESKTOP="" GLYPH_PROMPT="? " sway-launcher
 ```
 
+If `fzf` is not in your `$PATH` you can specify the path by supplying a value to the `FZF_COMMAND` variable.
+```
+set $menu exec $term -e env FZF_COMMAND="/path/to/fzf" sway-launcher
+```
+
 By default, the launcher will use a generic & WM-agnostic command to launch the selected program. 
 However, it will detect if its output is being piped to another program and merely print 
 the selected command in that case - instead of launching it by itself. You can use this to integrate the launcher with other tools.

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -12,6 +12,7 @@ trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 IFS=$'\n\t'
 DEL=$'\34'
 
+FZF_COMMAND="${FZF_COMMAND:=fzf}"
 TERMINAL_COMMAND="${TERMINAL_COMMAND:="$TERMINAL -e"}"
 GLYPH_COMMAND="${GLYPH_COMMAND-  }"
 GLYPH_DESKTOP="${GLYPH_DESKTOP-  }"
@@ -312,7 +313,7 @@ for PROVIDER_NAME in "${!PROVIDERS[@]}"; do
 done
 
 readarray -t COMMAND_STR <<<$(
-  fzf --ansi +s -x -d '\034' --nth ..3 --with-nth 3 \
+  ${FZF_COMMAND} --ansi +s -x -d '\034' --nth ..3 --with-nth 3 \
     --print-query \
     --preview "$0 describe {2} {1}" \
     --preview-window=up:2:noborder \


### PR DESCRIPTION
I added a way to override the path to the `fzf` binary. This is useful if you have it installed outside of the `$PATH` of sway.
