### PR TITLE
Support customizing the margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ If you want to be able to autostart applications , this script provides a functi
 ### Configure fzf preview window
 You can configure the fzf preview window using the environment variable `PREVIEW_WINDOW` (default: `up:2:noborder`). For example, if you prefer a taller window, you could use `PREVIEW_WINDOW=5:up`. The content of `PREVIEW_WINDOW` is passed to the `--preview-window` option, so check out the fzf manual for further details.
 
+### Changing the margin
+The margin of the window can be configured using the `SLD_MARGIN` environment variable.
+See [--margin in man fzf](https://man.archlinux.org/man/fzf.1.en#margin=) for the format.
+
 ## Extending the launcher
 
 In addition to desktop application entries and binaries, you can extend `sway-launcher-desktop` with custom item providers.

--- a/sway-launcher-desktop.sh
+++ b/sway-launcher-desktop.sh
@@ -322,7 +322,7 @@ readarray -t COMMAND_STR <<<$(
     --preview-window="${PREVIEW_WINDOW}" \
     --no-multi --cycle \
     --prompt="${GLYPH_PROMPT-# }" \
-    --header='' --no-info --margin='1,2' \
+    --header='' --no-info --margin="${SLD_MARGIN:-1,2}" \
     --color='16,gutter:-1' \
     <"$FZFPIPE"
 ) || exit 1


### PR DESCRIPTION
If foot already has padding set (e.g. `-o pad=16x16`), the paddings are combined making it a bit too much. This allows the user to disable, or completely customize, to the padding using `SLD_MARGIN=0`.

I've prefixed the env var with **S**way **L**auncher **D**esktop (SLD) to prevent any collision with other programs' environment variables. If you want me to change this, let me know.